### PR TITLE
chore: fix dev workflow

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -69,7 +69,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          git clone --depth 1 git@github.com:adbc-drivers/dev
+          git clone --depth 1 https://github.com/adbc-drivers/dev
           python dev/adbc_drivers_dev/title_check.py $(pwd) "$PR_TITLE"
 
   lint:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ copyright/license headers are present.
 Add this repository to your `.pre-commit-config.yaml`:
 
 ```yaml
-- repo: git@github.com:adbc-drivers/dev
+- repo: https://github.com/adbc-drivers/dev
   rev: "<latest rev on main>"
   hooks:
   - id: rat


### PR DESCRIPTION
## What's Changed

Don't use SSH URLs to clone public repos, use HTTPS.
