### PR TITLE
fix(adbc_drivers_dev/rat): handle binary files more gracefully

### DIFF
--- a/adbc_drivers_dev/rat/cli.py
+++ b/adbc_drivers_dev/rat/cli.py
@@ -153,8 +153,12 @@ def main():
                     lines = []
                     for _ in range(20):
                         lines.append(f.readline())
-
-                content = b" ".join(lines).decode("utf-8")
+                try:
+                    content = b" ".join(lines).decode("utf-8")
+                except UnicodeDecodeError:
+                    # decode will fail on non-text files so just use empty
+                    # content so RAT will fail if the file isn't excluded
+                    content = ""
                 content = sep_re.sub(" ", content)
 
                 if not copyright_re.search(content):


### PR DESCRIPTION
## What's Changed

Makes the RAT pre-commit command mores resilient when it encounters binary files. Without this change, pre-commit just fails with a cryptic UnicdoeDecodeError without any context for which file failed. Handling rat-excludes happens below this line so excluding any files you suspect may be the cause doesn't help.