### PR TITLE
chore: target macOS 11 as minimum

### DIFF
--- a/adbc_drivers_dev/make.py
+++ b/adbc_drivers_dev/make.py
@@ -243,8 +243,8 @@ def build(
             env[var] = os.environ[var]
 
     if platform.system() == "Darwin":
-        append_flags(env, "CGO_CFLAGS", "-mmacosx-version-min=10.12")
-        append_flags(env, "CGO_LDFLAGS", "-mmacosx-version-min=10.12")
+        append_flags(env, "CGO_CFLAGS", "-mmacosx-version-min=11.0")
+        append_flags(env, "CGO_LDFLAGS", "-mmacosx-version-min=11.0")
 
     if ci and platform.system() == "Linux":
         env["SOURCE_ROOT"] = str(repo_root)


### PR DESCRIPTION
## What's Changed

Many things can't target 10.12 and anyways, 10.x is long out of support.