### PR TITLE
fix: don't hardcode current year into copyright header check

### DIFF
--- a/adbc_drivers_dev/copyright.py
+++ b/adbc_drivers_dev/copyright.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import argparse
-import datetime
 import fnmatch
 import re
 import subprocess
@@ -31,8 +30,7 @@ def main():
     args = parser.parse_args()
     root = args.root.resolve()
 
-    year = datetime.datetime.now().year
-    pattern = rf"Copyright \(c\) ([0-9]+-)?{year} Columnar Technologies Inc\. +All rights reserved\."
+    pattern = r"Copyright \(c\) ([0-9]{4}-)?[0-9]{4} Columnar Technologies Inc\. +All rights reserved\."
     header = re.compile(pattern.encode())
 
     # ------------------------------------------------------------


### PR DESCRIPTION
## What's Changed

I think I meant to be smarter and check that files modified this year had the current year, but that would require a more involved check since right now we just scan all files without info of what's actually modified.