### PR TITLE
feat: allow specifying secrets for workflows

### DIFF
--- a/adbc_drivers_dev/templates/dev_issues.yaml
+++ b/adbc_drivers_dev/templates/dev_issues.yaml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       issues: write
     if: github.event.comment.body == 'take'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:

--- a/adbc_drivers_dev/templates/dev_pr.yaml
+++ b/adbc_drivers_dev/templates/dev_pr.yaml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   pr_standard:
     name: "Check PR"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -273,6 +273,12 @@ jobs:
 
       - name: Validate
         if: runner.os == 'Linux'
+<% if secrets["validate"] %>
+        env:
+<% for name, val in secrets["validate"].items() %>
+          <{name}>: ${{ secrets.<{val}> }}
+<% endfor %>
+<% endif %>
         working-directory: go
         run: |
           set -a
@@ -361,9 +367,9 @@ jobs:
 
       - name: Build Library
         working-directory: go
-<% if secrets and "build" in secrets %>
+<% if secrets["build:release"] %>
         env:
-<% for name, val in secrets["build"].items() %>
+<% for name, val in secrets["build:release"].items() %>
           <{name}>: ${{ secrets.<{val}> }}
 <% endfor %>
 <% endif %>


### PR DESCRIPTION
## What's Changed

The new section looks like this:

```toml
[secrets]
SNOWFLAKE_DATABASE = { secret = "SNOWFLAKE_DATABASE", contexts = ["validate"] }
SNOWFLAKE_SCHEMA = { secret = "SNOWFLAKE_SCHEMA", contexts = ["validate"] }
SNOWFLAKE_URI = { secret = "SNOWFLAKE_URI", contexts = ["validate"] }
```

Also, use `ubuntu-slim` in a few places. This won't matter for public repos but should save a bit for private repos.

Closes #12.
Closes #35.
