### PR TITLE
feat: log in to ghcr.io before building

### DIFF
--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -296,6 +296,11 @@ jobs:
           workload_identity_provider: ${{ secrets.gcloud_workload_identity_provider }}
 <% endif %>
 
+      - name: Log in to ghcr.io
+        if: runner.os == 'Linux'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Build Library
         working-directory: go
         run: |


### PR DESCRIPTION
## What's Changed

This way we don't have to rebuild the Docker image for Linux builds.