### PR TITLE
fix: don't assume script builds will use special tag format

### DIFF
--- a/adbc_drivers_dev/make.py
+++ b/adbc_drivers_dev/make.py
@@ -152,19 +152,11 @@ def detect_version(
             raise ValueError(f"{driver_root} is not in a git repository")
         repo_root = repo_root.parent
 
-    is_script_build = not any(
-        (driver_root / name).is_file() for name in ("Cargo.toml", "go.mod")
-    )
-    if is_script_build:
-        # We're going to assume custom builds like this are effectively the
-        # entire repo, and use just plain tags "v1.0.0".
+    prefix = str(driver_root.relative_to(repo_root))
+    if prefix == ".":
         prefix = "v"
     else:
-        prefix = str(driver_root.relative_to(repo_root))
-        if prefix == ".":
-            prefix = "v"
-        else:
-            prefix = f"{prefix}/v"
+        prefix = f"{prefix}/v"
 
     tags = check_output(
         [


### PR DESCRIPTION
On reflection it was better to just stay consistent with the tag format (so script builds will use `src/v0.1.0`)

