### PR TITLE
feat: allow renaming temporary artifact (for Databricks)

### DIFF
--- a/adbc_drivers_dev/make.py
+++ b/adbc_drivers_dev/make.py
@@ -565,7 +565,8 @@ def task_build():
             elif any(filename.endswith(ext) for ext in extensions):
                 file_deps.append(Path(dirname) / filename)
 
-    target = f"libadbc_driver_{driver}.{EXT}"
+    target_name = get_var("TARGET_NAME", f"adbc_driver_{driver}")
+    target = f"lib{target_name}.{EXT}"
 
     if lang == "go":
         actions = [


### PR DESCRIPTION
## What's Changed

Databricks chose a different name for their crate, resulting in a different output file name; allow that to be overridden here.