### PR TITLE
feat: add support for overriding lang subdir

### DIFF
--- a/adbc_drivers_dev/generate.py
+++ b/adbc_drivers_dev/generate.py
@@ -94,6 +94,10 @@ class LangConfig(BaseModel):
         default_factory=LangBuildConfig,
         description="Configuration for building the driver.",
     )
+    subdir: str | None = Field(
+        default=None,
+        description="Override the default subdirectory for this language. Use '.' to place files at the repository root.",
+    )
     skip_test: bool = Field(
         default=False,
         alias="skip-test",

--- a/adbc_drivers_dev/generate.py
+++ b/adbc_drivers_dev/generate.py
@@ -64,10 +64,10 @@ class LangBuildConfig(BaseModel):
         description="A list of additional arguments to pass to adbc-make.",
     )
 
-    go_mod_path: str = Field(
-        default="go",
+    go_mod_path: str | None = Field(
+        default=None,
         alias="go-mod-path",
-        description="Path containing the go.mod file for Go drivers. Used to cache dependencies in CI.",
+        description="Path containing the go.mod file for Go drivers. Used to cache dependencies in CI. Defaults to the language subdir.",
     )
 
     lang_tools: list[str] = Field(

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -143,9 +143,9 @@ jobs:
 <% if "go" in lang_tools %>
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          cache-dependency-path: <{lang_config.build.go_mod_path}>/go.sum
+          cache-dependency-path: <{go_mod_path}>/go.sum
           check-latest: true
-          go-version-file: <{lang_config.build.go_mod_path}>/go.mod
+          go-version-file: <{go_mod_path}>/go.mod
 <% endif %>
 <% if "rust" in lang_tools %>
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606  # v1.15.4
@@ -323,9 +323,9 @@ jobs:
 <% if "go" in lang_tools %>
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          cache-dependency-path: <{lang_config.build.go_mod_path}>/go.sum
+          cache-dependency-path: <{go_mod_path}>/go.sum
           check-latest: true
-          go-version-file: <{lang_config.build.go_mod_path}>/go.mod
+          go-version-file: <{go_mod_path}>/go.mod
 <% endif %>
 <% if "rust" in lang_tools %>
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606  # v1.15.4
@@ -504,9 +504,9 @@ jobs:
 <% if "go" in lang_tools %>
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          cache-dependency-path: <{lang_config.build.go_mod_path}>/go.sum
+          cache-dependency-path: <{go_mod_path}>/go.sum
           check-latest: true
-          go-version-file: <{lang_config.build.go_mod_path}>/go.mod
+          go-version-file: <{go_mod_path}>/go.mod
 <% endif %>
 <% if "rust" in lang_tools %>
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606  # v1.15.4

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -34,7 +34,7 @@ on:
     branches:
       - main
     paths:
-      - "<{lang_subdir}>/**"
+      - "<{lang_path_glob}>"
 <% for path in pull_request_trigger_paths %>
       - <{path}>
 <% endfor %>
@@ -42,12 +42,12 @@ on:
   push:
 <% if release %>
     tags:
-      - "<{lang_subdir}>/v**"
+      - "<{lang_tag_prefix}>v**"
 <% else %>
     branches:
       - main
     paths:
-      - "<{lang_subdir}>/**"
+      - "<{lang_path_glob}>"
 <% for path in pull_request_trigger_paths %>
       - <{path}>
 <% endfor %>
@@ -836,8 +836,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: <{ lang_subdir }>
         run: |
-          git tag <{ lang_subdir }>/v1000.0.0
-          tag=<{ lang_subdir }>/v1000.0.0
+          git tag <{lang_tag_prefix}>v1000.0.0
+          tag=<{lang_tag_prefix}>v1000.0.0
 
           pixi run release --dry-run $(pwd) $tag
           echo gh release upload $tag $(find ~/packages -name '*.tar.gz') $(find ~/packages -name 'manifest.yaml') $(find ~/packages -name '*.md')
@@ -847,8 +847,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: <{ lang_subdir }>
         run: |
-          git tag <{ lang_subdir }>/v1000.0.0
-          tag=<{ lang_subdir }>/v1000.0.0
+          git tag <{lang_tag_prefix}>v1000.0.0
+          tag=<{lang_tag_prefix}>v1000.0.0
 
           pixi run release --dry-run $(pwd) $tag
           echo gh release upload $tag $(find ~/packages -name '*.tar.gz') $(find ~/packages -name 'manifest.yaml') $(find ~/packages -name '*.md')

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -124,12 +124,14 @@ def generate_workflows(args) -> int:
         lang_tools.update(lang_config.build.lang_tools)
 
         template = env.get_template("test.yaml")
+        go_mod_path = lang_config.build.go_mod_path or lang_subdir
         lang_ctx = {
             "lang": lang,
             "lang_human": lang_human,
             "lang_subdir": lang_subdir,
             "lang_tag_prefix": lang_tag_prefix,
             "lang_path_glob": lang_path_glob,
+            "go_mod_path": go_mod_path,
             "lang_config": lang_config,
             "lang_tools": lang_tools,
         }

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -114,7 +114,11 @@ def generate_workflows(args) -> int:
         if not lang_config:
             continue
 
-        lang_subdir = lang_config.subdir if lang_config.subdir is not None else lang_subdir_default
+        lang_subdir = (
+            lang_config.subdir
+            if lang_config.subdir is not None
+            else lang_subdir_default
+        )
         lang_tag_prefix = "" if lang_subdir == "." else f"{lang_subdir}/"
         lang_path_glob = "**" if lang_subdir == "." else f"{lang_subdir}/**"
 

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -109,10 +109,14 @@ def generate_workflows(args) -> int:
     }
 
     retcode = 0
-    for lang, (lang_human, lang_subdir) in langs.items():
+    for lang, (lang_human, lang_subdir_default) in langs.items():
         lang_config = params.lang.get(lang)
         if not lang_config:
             continue
+
+        lang_subdir = lang_config.subdir if lang_config.subdir is not None else lang_subdir_default
+        lang_tag_prefix = "" if lang_subdir == "." else f"{lang_subdir}/"
+        lang_path_glob = "**" if lang_subdir == "." else f"{lang_subdir}/**"
 
         (args.repository / lang_subdir).mkdir(parents=True, exist_ok=True)
 
@@ -120,20 +124,25 @@ def generate_workflows(args) -> int:
         lang_tools.update(lang_config.build.lang_tools)
 
         template = env.get_template("test.yaml")
+        lang_ctx = {
+            "lang": lang,
+            "lang_human": lang_human,
+            "lang_subdir": lang_subdir,
+            "lang_tag_prefix": lang_tag_prefix,
+            "lang_path_glob": lang_path_glob,
+            "lang_config": lang_config,
+            "lang_tools": lang_tools,
+        }
         write_workflow(
             workflows,
             template,
             f"{lang}_test.yaml",
             {
                 **params.to_dict(),
+                **lang_ctx,
                 "pull_request_trigger_paths": [f".github/workflows/{lang}_test.yaml"],
                 "release": False,
                 "workflow_name": "Test",
-                "lang": lang,
-                "lang_human": lang_human,
-                "lang_subdir": lang_subdir,
-                "lang_config": lang_config,
-                "lang_tools": lang_tools,
             },
         )
         write_workflow(
@@ -142,13 +151,9 @@ def generate_workflows(args) -> int:
             f"{lang}_release.yaml",
             {
                 **params.to_dict(),
+                **lang_ctx,
                 "release": True,
                 "workflow_name": "Release",
-                "lang": lang,
-                "lang_human": lang_human,
-                "lang_subdir": lang_subdir,
-                "lang_config": lang_config,
-                "lang_tools": lang_tools,
             },
         )
         template = env.get_template("go_test_pr.yaml")
@@ -169,10 +174,7 @@ def generate_workflows(args) -> int:
             "pixi.toml",
             {
                 **params.to_dict(),
-                "lang": lang,
-                "lang_human": lang_human,
-                "lang_subdir": lang_subdir,
-                "lang_config": lang_config,
+                **lang_ctx,
             },
         )
 

--- a/schema/generate-schema.json
+++ b/schema/generate-schema.json
@@ -16,6 +16,79 @@
       "title": "AwsConfig",
       "type": "object"
     },
+    "LangBuildConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "additional-make-args": {
+          "description": "A list of additional arguments to pass to adbc-make.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Additional-Make-Args",
+          "type": "array"
+        },
+        "go-mod-path": {
+          "default": "go",
+          "description": "Path containing the go.mod file for Go drivers. Used to cache dependencies in CI.",
+          "title": "Go-Mod-Path",
+          "type": "string"
+        },
+        "lang-tools": {
+          "description": "Install tools for these languages to use in the build.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Lang-Tools",
+          "type": "array"
+        },
+        "environment-contexts": {
+          "description": "What parts of the build require the environment.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Environment-Contexts",
+          "type": "array"
+        }
+      },
+      "title": "LangBuildConfig",
+      "type": "object"
+    },
+    "LangConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/LangBuildConfig",
+          "description": "Configuration for building the driver."
+        },
+        "subdir": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Override the default subdirectory for this language. Use '.' to place files at the repository root.",
+          "title": "Subdir"
+        },
+        "skip-test": {
+          "default": false,
+          "description": "Whether to skip test workflows (primarily useful for build-only drivers)",
+          "title": "Skip-Test",
+          "type": "boolean"
+        },
+        "skip-validate": {
+          "default": false,
+          "description": "Whether to skip the validation suite in CI (this should only be used temporarily while setting up a driver)",
+          "title": "Skip-Validate",
+          "type": "boolean"
+        }
+      },
+      "title": "LangConfig",
+      "type": "object"
+    },
     "SecretConfigDict": {
       "additionalProperties": false,
       "description": "Secret configuration with explicit secret name and contexts.",
@@ -29,6 +102,7 @@
           "description": "Workflow contexts where this secret should be available",
           "items": {
             "enum": [
+              "build:test",
               "build:release",
               "test",
               "validate"
@@ -51,8 +125,14 @@
       "properties": {
         "extra-dependencies": {
           "additionalProperties": true,
-          "description": "Additional dependencies to install for validation workflows. Specify as key-value pairs. Example:\n\n[validation.extra-dependencies]\npytest = \"^7.0\"\nblack = \"*\"",
+          "description": "Additional dependencies to install for validation workflows. Specify as key-value pairs. Example:\n\n[validation.extra-dependencies]\npytest = \">=7,<8\"\nblack = \"*\"",
           "title": "Extra-Dependencies",
+          "type": "object"
+        },
+        "extra-pypi-dependencies": {
+          "additionalProperties": true,
+          "description": "Additional dependencies to install for validation workflows. Specify as key-value pairs. Example:\n\n[validation.extra-pypi-dependencies]\npytest = \">=7,<8\"\nblack = \"*\"",
+          "title": "Extra-Pypi-Dependencies",
           "type": "object"
         }
       },
@@ -64,6 +144,19 @@
   "additionalProperties": false,
   "description": "You can validate your generate.toml against this schema with tools like tombi (https://tombi-toml.github.io/tombi/docs/linter). Requires placing a `#:schema` directive at the top of your generate.toml file.",
   "properties": {
+    "repository": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "GitHub repository name (if different from driver name)",
+      "title": "Repository"
+    },
     "driver": {
       "default": "(unknown)",
       "description": "Driver name. Should be lowercase (e.g., postgresql, sqlite)",
@@ -85,15 +178,22 @@
     },
     "private": {
       "default": false,
-      "description": "Whether the driver is private. Most drivers will be non-private.",
+      "description": "Whether the driver is private. Most drivers will be not be private so you can omit this.",
       "title": "Private",
       "type": "boolean"
     },
     "lang": {
       "additionalProperties": {
-        "type": "boolean"
+        "anyOf": [
+          {
+            "$ref": "#/$defs/LangConfig"
+          },
+          {
+            "type": "null"
+          }
+        ]
       },
-      "description": "Programming languages to enable workflows for. Only go is really supported right now. Keys should be lowercase. Set to true to enable, false to disable. Example:\n\n[lang]\ngo = true\npython = false",
+      "description": "Programming language(s) to enable workflows for. Only go and rust are supported. Keys should be lowercase. Set to true to enable with default config, or false (the default) to disable. Example:\n\n[lang]\ngo = true\n\n[lang.rust.build]\nadditional-make-args = [\"example\"]",
       "title": "Lang",
       "type": "object"
     },
@@ -108,7 +208,7 @@
           }
         ]
       },
-      "description": "Secrets to enable in workflows. By default, no secrets are available in your generated workflows unless you specify them here.\n\nFor a secret available in all workflows, use simple syntax:\n\n[secrets]\nMY_TOKEN = \"GITHUB_SECRET_NAME\"\n\nTo restrict secrets to specific workflows, use contexts (valid values: 'build:release', 'test', 'validate'):\n\n[secrets.DB_PASSWORD]\nsecret = \"TEST_DB_SECRET\"\ncontexts = [\"test\", \"validate\"]",
+      "description": "Secrets to enable in workflows. By default, no secrets are available in your generated workflows unless you specify them here.\n\nTo make a secret available in all workflows, use the simple syntax:\n\n[secrets]\nMY_TOKEN = \"GITHUB_SECRET_NAME\"\n\nIf you want more fine-grained control, you can restrict secrets to specific workflows. To do this, specify contexts contexts ('build:release', 'test', 'validate') like this:\n\n[secrets.DB_PASSWORD]\nsecret = \"TEST_DB_SECRET\"\ncontexts = [\"test\", \"validate\"]",
       "title": "Secrets",
       "type": "object"
     },
@@ -122,7 +222,7 @@
         }
       ],
       "default": null,
-      "description": "Enables AWS authentication in workflows. Automatically adds AWS_ROLE and AWS_ROLE_SESSION_NAME secrets, and sets id_token permissions. Example:\n\naws.region = \"us-west-2\"\n\nOr:\n\n[aws]\nregion = \"us-west-2\""
+      "description": "Enables AWS authentication in workflows. Automatically adds AWS_ROLE and AWS_ROLE_SESSION_NAME secrets, and sets id_token permissions. Example:\n\n[aws]\nregion = \"us-west-2\""
     },
     "gcloud": {
       "default": false,

--- a/schema/generate-schema.json
+++ b/schema/generate-schema.json
@@ -28,10 +28,17 @@
           "type": "array"
         },
         "go-mod-path": {
-          "default": "go",
-          "description": "Path containing the go.mod file for Go drivers. Used to cache dependencies in CI.",
-          "title": "Go-Mod-Path",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path containing the go.mod file for Go drivers. Used to cache dependencies in CI. Defaults to the language subdir.",
+          "title": "Go-Mod-Path"
         },
         "lang-tools": {
           "description": "Install tools for these languages to use in the build.",


### PR DESCRIPTION
## What's Changed

Adds and wires through a new option to `LangConfig` called `subdir` that lets driver repos use a non-default subdirectory (or the repo root) for their driver, rather than having to put their driver code in a language-specific subdir. Having a pattern for multi-lang driver repos is good but I think supporting single-lang driver repos is worthwhile.

For example, a Go driver at the root of a repo would enable Go and set their subdir with,

```toml
driver = "something"
private = false

[lang.go]
subdir = "."
```

Also re-generates the generate schema and we were out of date so there are extra changes in there.