### PR TITLE
fix: minor issues with go_mod_path construction and use

### DIFF
--- a/adbc_drivers_dev/templates/dev.yaml
+++ b/adbc_drivers_dev/templates/dev.yaml
@@ -52,9 +52,9 @@ jobs:
 <% if lang.get("go") %>
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
-          cache-dependency-path: go/go.sum
+          cache-dependency-path: <{go_mod_path}>/go.sum
           check-latest: true
-          go-version-file: go/go.mod
+          go-version-file: <{go_mod_path}>/go.mod
 <% endif %>
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -128,7 +128,11 @@ def generate_workflows(args) -> int:
         lang_tools.update(lang_config.build.lang_tools)
 
         template = env.get_template("test.yaml")
-        go_mod_path = (lang_config.build.go_mod_path or lang_subdir) if lang == "go" else langs["go"][1]
+        go_mod_path = (
+            (lang_config.build.go_mod_path or lang_subdir)
+            if lang == "go"
+            else langs["go"][1]
+        )
         lang_ctx = {
             "lang": lang,
             "lang_human": lang_human,

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -208,6 +208,7 @@ def generate_workflows(args) -> int:
             dev,
             {
                 **params.to_dict(),
+                "go_mod_path": go_mod_path,
             },
         )
 

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -128,7 +128,7 @@ def generate_workflows(args) -> int:
         lang_tools.update(lang_config.build.lang_tools)
 
         template = env.get_template("test.yaml")
-        go_mod_path = lang_config.build.go_mod_path or lang_subdir
+        go_mod_path = (lang_config.build.go_mod_path or lang_subdir) if lang == "go" else langs["go"][1]
         lang_ctx = {
             "lang": lang,
             "lang_human": lang_human,


### PR DESCRIPTION
## What's Changed

Fixes two minor things with go_mod_path. Without this, the generated `dev.yaml` will use a hard coded `go/go.mod` path. I missed this in aa2b3acc157679aa51adf1b727336ee5e256d733. The other thing is just a minor safety thing, that `go_mod_path` didn't have a default.

Tested locally with a test repo:

```sh
$ cat .github/workflows/generate.toml | grep subdir
subdir = "."
$ adbc-gen-workflow generate .
$ grep "go\." ".github/workflows/dev.yaml"
          cache-dependency-path: ./go.sum
          go-version-file: ./go.mod
```