### PR TITLE
chore: use public ARM runners

### DIFF
--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -461,11 +461,7 @@ jobs:
       matrix:
         include:
           - { platform: linux, arch: amd64, runner: ubuntu-latest }
-<% if private %>
-          - { platform: linux, arch: arm64, runner: private-ubuntu-24.04-arm }
-<% else %>
           - { platform: linux, arch: arm64, runner: ubuntu-24.04-arm }
-<% endif %>
           - { platform: macos, arch: arm64, runner: macos-latest }
           - { platform: windows, arch: amd64, runner: windows-latest }
 <% if environment and "build:release" in lang_config.build.environment_contexts %>


### PR DESCRIPTION
We currently use a paid runner for some repositories, but there's no need to anymore.

https://github.blog/changelog/2026-01-29-arm64-standard-runners-are-now-available-in-private-repositories/

