### PR TITLE
feat: remove -s option build option to include symbols in Golang artifacts

### DIFF
--- a/adbc_drivers_dev/make.py
+++ b/adbc_drivers_dev/make.py
@@ -283,7 +283,8 @@ def build_go(
     prop = "github.com/adbc-drivers/driverbase-go/driverbase.infoDriverVersion"
     ldflags = " ".join(
         [
-            "-s",
+            # Don't exclude symbols (-s) so panics will have symbol information
+            # This will exclude DWARF debug tables (-w).
             "-w",
             f"-X {prop}={version}",
         ]


### PR DESCRIPTION
## What's Changed

- Removes the -s option in the Golang build so that symbols will be included in built artifacts.

Closes #149.
