### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/adbc_drivers_dev/.env
+++ b/adbc_drivers_dev/.env
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO=1.26.1
+GO=1.26.4
 LIBCLANG=18.1.1
 MANYLINUX=manylinux2014
 RUST=1.93.1


### PR DESCRIPTION
## Summary

Bumps the manylinux builder image's Go toolchain from **1.26.1** to **1.26.4** in `adbc_drivers_dev/.env`.

The `Docker Compose Build` workflow tags images as `ghcr.io/adbc-drivers/dev:${MANYLINUX}-go${GO}`, so merging this (and running the build with `push=true`) publishes a new `manylinux2014-go1.26.4` image alongside the existing `go1.26.1` one.

## Why

`adbc-drivers/snowflake#149` bumps the Snowflake driver's `go/go.mod` to `go 1.26.4` to clear stdlib CVEs. The shipped `.so` is compiled **inside** the manylinux container, whose Go is pinned here. With the container still on 1.26.1, the in-container build runs as `--user 1001`, sees the `go 1.26.4` directive, and (under the default `GOTOOLCHAIN=auto`) tries to auto-download the 1.26.4 toolchain into `GOPATH=/go` — which it cannot create:

```
go: could not create module cache: mkdir /go: permission denied
```

Bumping the baked-in toolchain to 1.26.4 makes `GOTOOLCHAIN=auto` resolve to the local toolchain (no download), so the build succeeds **and** the artifact is genuinely compiled on 1.26.4.

## Follow-up

After this merges and the `manylinux2014-go1.26.4` image is pushed, the consuming driver repos pick it up when their `pixi.lock` is re-pinned to this commit.