### PR TITLE
feat!: allow specifying environment per validation config

### DIFF
--- a/adbc_drivers_dev/generate.py
+++ b/adbc_drivers_dev/generate.py
@@ -91,16 +91,22 @@ class LangValidateSpec(BaseModel):
     }
 
     service_name: str = Field(
+        alias="service-name",
         default="test-service",
         description="docker-compose service to start",
     )
     vendor_version: str = Field(
+        alias="vendor-version",
         default="latest",
         description="version to pass to the validation suite",
     )
     environment: str | None = Field(
         default=None,
         description="Name of a GitHub Actions Environment to activate",
+    )
+    azure: bool = Field(
+        default=False,
+        description="Log in to Azure in this config. Expects AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_CLIENT_SECRET secrets",
     )
 
 

--- a/adbc_drivers_dev/generate.py
+++ b/adbc_drivers_dev/generate.py
@@ -75,11 +75,9 @@ class LangBuildConfig(BaseModel):
         alias="lang-tools",
         description="Install tools for these languages to use in the build.",
     )
-
-    environment_contexts: list[str] = Field(
-        default_factory=lambda: ["test", "validate"],
-        alias="environment-contexts",
-        description="What parts of the build require the environment.",
+    environment: str | None = Field(
+        default=None,
+        description="Name of a GitHub Actions Environment to activate",
     )
 
 
@@ -99,6 +97,10 @@ class LangValidateSpec(BaseModel):
     vendor_version: str = Field(
         default="latest",
         description="version to pass to the validation suite",
+    )
+    environment: str | None = Field(
+        default=None,
+        description="Name of a GitHub Actions Environment to activate",
     )
 
 
@@ -139,6 +141,19 @@ class LangTestConfig(BaseModel):
         default="test-service",
         description="docker-compose service to start for tests",
     )
+    environment: str | None = Field(
+        default=None,
+        description="Name of a GitHub Actions Environment to activate",
+    )
+
+
+class LangTestPackagesConfig(BaseModel):
+    """Options for the Test Packages step."""
+
+    environment: str | None = Field(
+        default=None,
+        description="Name of a GitHub Actions Environment to activate",
+    )
 
 
 class LangConfig(BaseModel):
@@ -159,6 +174,11 @@ class LangConfig(BaseModel):
     test: LangTestConfig = Field(
         default_factory=LangTestConfig,
         description="Configuration for the driver test suite.",
+    )
+    test_packages: LangTestPackagesConfig = Field(
+        default_factory=LangTestPackagesConfig,
+        alias="test-packages",
+        description="Configuration for the Test Packages step.",
     )
     validation: LangValidationConfig = Field(
         default_factory=LangValidationConfig,
@@ -218,6 +238,8 @@ class GenerateConfig(BaseModel):
             "title": "Schema for generate.toml",
             "description": "You can validate your generate.toml against this schema with tools like tombi (https://tombi-toml.github.io/tombi/docs/linter). Requires placing a `#:schema` directive at the top of your generate.toml file.",
         },
+        "validate_by_name": True,
+        "validate_by_alias": True,
     }
 
     repository: str | None = Field(
@@ -229,13 +251,14 @@ class GenerateConfig(BaseModel):
         default="(unknown)",
         description="Driver name. Should be lowercase (e.g., postgresql, sqlite)",
     )
-    environment: str | None = Field(
-        default=None,
-        description="Name of a GitHub Actions Environment to use when including secrets in workflows",
-    )
     private: bool = Field(
         default=False,
         description="Whether the driver is private. Most drivers will be not be private so you can omit this.",
+    )
+    concurrency_key: str | None = Field(
+        default=None,
+        alias="concurrency-key",
+        description="Concurrency group for GitHub Actions. If specified, it effectively blocks test and release pipelines from running concurrently.",
     )
     lang: dict[str, LangConfig | None] = Field(
         default_factory=dict,
@@ -295,11 +318,11 @@ gcloud = true"""
     _processed_secrets: dict[str, dict[str, str]] = PrivateAttr(default_factory=dict)
     _permissions: dict[str, bool] = PrivateAttr(default_factory=dict)
 
-    @field_validator("environment")
+    @field_validator("concurrency_key")
     @classmethod
-    def validate_environment(cls, v: str | None) -> str | None:
+    def validate_concurrency_key(cls, v: str | None) -> str | None:
         if v is not None and not v.strip():
-            raise ValueError("environment must be non-empty if provided")
+            raise ValueError("concurrency-key must be non-empty if provided")
         return v
 
     @field_validator("lang", mode="before")
@@ -366,8 +389,8 @@ gcloud = true"""
         return {
             "driver": self.driver,
             "repository": self.repository,
-            "environment": self.environment,
             "private": self.private,
+            "concurrency_key": self.concurrency_key,
             "lang": self.lang,
             "secrets": self._processed_secrets,
             "permissions": self._permissions,

--- a/adbc_drivers_dev/generate.py
+++ b/adbc_drivers_dev/generate.py
@@ -14,6 +14,7 @@
 
 import typing
 
+import pydantic
 from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
 # Define workflow contexts in a single location
@@ -340,6 +341,15 @@ gcloud = true"""
             for k, v in value.items()
         }
 
+    @pydantic.computed_field
+    def azure(self) -> int:
+        return any(
+            config.azure
+            for lang in self.lang.values()
+            if lang
+            for config in lang.validation.configs
+        )
+
     @model_validator(mode="after")
     def default_repository(self) -> "GenerateConfig":
         if self.repository is None:
@@ -386,7 +396,7 @@ gcloud = true"""
         self._processed_secrets["all"] = all_secrets
 
         # Set permissions
-        if self.aws or self.gcloud:
+        if self.aws or self.gcloud or self.azure:
             self._permissions["id_token"] = True
 
         return self
@@ -401,6 +411,7 @@ gcloud = true"""
             "secrets": self._processed_secrets,
             "permissions": self._permissions,
             "aws": self.aws.model_dump() if self.aws else None,
+            "azure": self.azure,
             "gcloud": self.gcloud,
             "validation": {
                 "extra_dependencies": self.validation.extra_dependencies,

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -75,9 +75,10 @@ on:
 <% endif %>
 
 concurrency:
-<% if environment %>
-  # Must share concurrency group with release workflow since it also builds/tests
-  group: ${{ github.repository }}-${{ github.ref }}-<{environment.replace(' ', '-')}>
+<% if concurrency_key %>
+  # Effectively prevents parallel tests - usually used for cloud workflows
+  # Not necessary if you use environments + manual approval + trust the manual approval
+  group: ${{ github.repository }}-<{concurrency_key}>
 <% else %>
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
 <% endif %>
@@ -102,8 +103,8 @@ jobs:
           - { platform: linux, arch: amd64, runner: ubuntu-latest }
           - { platform: macos, arch: arm64, runner: macos-latest }
           - { platform: windows, arch: amd64, runner: windows-latest }
-<% if environment and "test" in lang_config.build.environment_contexts or "build:test" in lang_config.build.environment_contexts %>
-    environment: <{environment}>
+<% if lang_config.test.environment %>
+    environment: <{lang_config.test.environment}>
 <% endif %>
     permissions:
       contents: read
@@ -289,11 +290,9 @@ jobs:
         include:
           # I think we only need to test one platform, but we can change that later
 <% for config in lang_config.validation.configs %>
-          - { platform: linux, arch: amd64, runner: ubuntu-latest, service_name: "<{config.service_name}>", vendor_version: "<{config.vendor_version}>" }
+          - { platform: linux, arch: amd64, runner: ubuntu-latest, service_name: "<{config.service_name}>", vendor_version: "<{config.vendor_version}>", environment: <% if config.environment %>"<{config.environment}>"<% else %>null<% endif %> }
 <% endfor %>
-<% if environment and "validate" in lang_config.build.environment_contexts or "build:test" in lang_config.build.environment_contexts %>
-    environment: <{environment}>
-<% endif %>
+    environment: ${{ matrix.environment }}
     permissions:
       contents: read
 <% if permissions.get("id_token") %>
@@ -484,8 +483,8 @@ jobs:
           - { platform: linux, arch: arm64, runner: ubuntu-24.04-arm }
           - { platform: macos, arch: arm64, runner: macos-latest }
           - { platform: windows, arch: amd64, runner: windows-latest }
-<% if environment and "build:release" in lang_config.build.environment_contexts %>
-    environment: <{environment}>
+<% if lang_config.build.environment  %>
+    environment: <{lang_config.build.environment}>
 <% endif %>
     permissions:
       contents: read
@@ -708,8 +707,8 @@ jobs:
           - { platform: linux, arch: amd64, runner: ubuntu-latest }
           - { platform: macos, arch: arm64, runner: macos-latest }
           - { platform: windows, arch: amd64, runner: windows-latest }
-<% if environment and "build:test" in lang_config.build.environment_contexts %>
-    environment: <{environment}>
+<% if lang_config.test_packages.environment %>
+    environment: <{lang_config.test_packages.environment}>
 <% endif %>
     steps:
       # for now, install dbc from main

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -290,7 +290,7 @@ jobs:
         include:
           # I think we only need to test one platform, but we can change that later
 <% for config in lang_config.validation.configs %>
-          - { platform: linux, arch: amd64, runner: ubuntu-latest, service_name: "<{config.service_name}>", vendor_version: "<{config.vendor_version}>", environment: <% if config.environment %>"<{config.environment}>"<% else %>null<% endif %> }
+          - { platform: linux, arch: amd64, runner: ubuntu-latest, service_name: "<{config.service_name}>", vendor_version: "<{config.vendor_version}>", environment: <% if config.environment %>"<{config.environment}>"<% else %>null<% endif %>, azure: <{ "true" if config.azure else "false" }> }
 <% endfor %>
     environment: ${{ matrix.environment }}
     permissions:
@@ -366,6 +366,15 @@ jobs:
           service_account: ${{ secrets.gcloud_service_account }}
           workload_identity_provider: ${{ secrets.gcloud_workload_identity_provider }}
 <% endif %>
+<% if azure %>
+      - name: Azure Login
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3.0.0
+        if: matrix.azure
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+<% endif %>
 
       - name: Log in to ghcr.io
         if: runner.os == 'Linux'
@@ -402,7 +411,7 @@ jobs:
         if: runner.os == 'Linux'
         working-directory: <{ lang_subdir }>
         run: |
-          if [[ -f compose.yaml ]]; then
+          if [[ -f compose.yaml ]] && [[ -n "${{ matrix.service_name }}" ]]; then
             if ! docker compose up --detach --wait ${{ matrix.service_name }}; then
               echo "Service failed to start"
               echo "Logs:"

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -249,7 +249,7 @@ jobs:
 
           if [[ -f ci/scripts/pre-test.sh ]]; then
             echo "Loading pre-test"
-            ./ci/scripts/pre-test.sh ${{ matrix.platform }} ${{ matrix.arch }}
+            ./ci/scripts/pre-test.sh ${{ matrix.platform }} ${{ matrix.arch }} "<{lang_config.test.service_name}>"
           fi
 
 <% if lang == "go" %>

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -144,8 +144,6 @@ def generate_workflows(args) -> int:
             "lang_tools": lang_tools,
         }
 
-        lang_ctx["azure"] = any(config.azure for config in lang_config.validation.configs)
-
         write_workflow(
             workflows,
             template,

--- a/adbc_drivers_dev/workflow.py
+++ b/adbc_drivers_dev/workflow.py
@@ -143,6 +143,9 @@ def generate_workflows(args) -> int:
             "lang_config": lang_config,
             "lang_tools": lang_tools,
         }
+
+        lang_ctx["azure"] = any(config.azure for config in lang_config.validation.configs)
+
         write_workflow(
             workflows,
             template,

--- a/schema/generate-schema.json
+++ b/schema/generate-schema.json
@@ -158,16 +158,16 @@
       "additionalProperties": false,
       "description": "A single config to validate.",
       "properties": {
-        "service_name": {
+        "service-name": {
           "default": "test-service",
           "description": "docker-compose service to start",
-          "title": "Service Name",
+          "title": "Service-Name",
           "type": "string"
         },
-        "vendor_version": {
+        "vendor-version": {
           "default": "latest",
           "description": "version to pass to the validation suite",
-          "title": "Vendor Version",
+          "title": "Vendor-Version",
           "type": "string"
         },
         "environment": {
@@ -182,6 +182,12 @@
           "default": null,
           "description": "Name of a GitHub Actions Environment to activate",
           "title": "Environment"
+        },
+        "azure": {
+          "default": false,
+          "description": "Log in to Azure in this config. Expects AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_CLIENT_SECRET secrets",
+          "title": "Azure",
+          "type": "boolean"
         }
       },
       "title": "LangValidateSpec",

--- a/schema/generate-schema.json
+++ b/schema/generate-schema.json
@@ -48,13 +48,18 @@
           "title": "Lang-Tools",
           "type": "array"
         },
-        "environment-contexts": {
-          "description": "What parts of the build require the environment.",
-          "items": {
-            "type": "string"
-          },
-          "title": "Environment-Contexts",
-          "type": "array"
+        "environment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of a GitHub Actions Environment to activate",
+          "title": "Environment"
         }
       },
       "title": "LangBuildConfig",
@@ -80,20 +85,128 @@
           "description": "Override the default subdirectory for this language. Use '.' to place files at the repository root.",
           "title": "Subdir"
         },
-        "skip-test": {
-          "default": false,
-          "description": "Whether to skip test workflows (primarily useful for build-only drivers)",
-          "title": "Skip-Test",
-          "type": "boolean"
+        "test": {
+          "$ref": "#/$defs/LangTestConfig",
+          "description": "Configuration for the driver test suite."
         },
-        "skip-validate": {
-          "default": false,
-          "description": "Whether to skip the validation suite in CI (this should only be used temporarily while setting up a driver)",
-          "title": "Skip-Validate",
-          "type": "boolean"
+        "test-packages": {
+          "$ref": "#/$defs/LangTestPackagesConfig",
+          "description": "Configuration for the Test Packages step."
+        },
+        "validation": {
+          "$ref": "#/$defs/LangValidationConfig",
+          "description": "Configuration for the driver validation suite."
         }
       },
       "title": "LangConfig",
+      "type": "object"
+    },
+    "LangTestConfig": {
+      "additionalProperties": false,
+      "description": "Options for test suite.",
+      "properties": {
+        "skip": {
+          "default": false,
+          "description": "Whether to skip tests in CI (this should only be used temporarily while setting up a driver or for build-only drivers)",
+          "title": "Skip",
+          "type": "boolean"
+        },
+        "service-name": {
+          "default": "test-service",
+          "description": "docker-compose service to start for tests",
+          "title": "Service-Name",
+          "type": "string"
+        },
+        "environment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of a GitHub Actions Environment to activate",
+          "title": "Environment"
+        }
+      },
+      "title": "LangTestConfig",
+      "type": "object"
+    },
+    "LangTestPackagesConfig": {
+      "description": "Options for the Test Packages step.",
+      "properties": {
+        "environment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of a GitHub Actions Environment to activate",
+          "title": "Environment"
+        }
+      },
+      "title": "LangTestPackagesConfig",
+      "type": "object"
+    },
+    "LangValidateSpec": {
+      "additionalProperties": false,
+      "description": "A single config to validate.",
+      "properties": {
+        "service_name": {
+          "default": "test-service",
+          "description": "docker-compose service to start",
+          "title": "Service Name",
+          "type": "string"
+        },
+        "vendor_version": {
+          "default": "latest",
+          "description": "version to pass to the validation suite",
+          "title": "Vendor Version",
+          "type": "string"
+        },
+        "environment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of a GitHub Actions Environment to activate",
+          "title": "Environment"
+        }
+      },
+      "title": "LangValidateSpec",
+      "type": "object"
+    },
+    "LangValidationConfig": {
+      "additionalProperties": false,
+      "description": "Options for validation suite.",
+      "properties": {
+        "skip": {
+          "default": false,
+          "description": "Whether to skip the validation suite in CI (this should only be used temporarily while setting up a driver)",
+          "title": "Skip",
+          "type": "boolean"
+        },
+        "configs": {
+          "description": "A list of configurations to run the validation suite with. Each configuration will be run in a separate job",
+          "items": {
+            "$ref": "#/$defs/LangValidateSpec"
+          },
+          "title": "Configs",
+          "type": "array"
+        }
+      },
+      "title": "LangValidationConfig",
       "type": "object"
     },
     "SecretConfigDict": {
@@ -170,7 +283,13 @@
       "title": "Driver",
       "type": "string"
     },
-    "environment": {
+    "private": {
+      "default": false,
+      "description": "Whether the driver is private. Most drivers will be not be private so you can omit this.",
+      "title": "Private",
+      "type": "boolean"
+    },
+    "concurrency-key": {
       "anyOf": [
         {
           "type": "string"
@@ -180,14 +299,8 @@
         }
       ],
       "default": null,
-      "description": "Name of a GitHub Actions Environment to use when including secrets in workflows",
-      "title": "Environment"
-    },
-    "private": {
-      "default": false,
-      "description": "Whether the driver is private. Most drivers will be not be private so you can omit this.",
-      "title": "Private",
-      "type": "boolean"
+      "description": "Concurrency group for GitHub Actions. If specified, it effectively blocks test and release pipelines from running concurrently.",
+      "title": "Concurrency-Key"
     },
     "lang": {
       "additionalProperties": {

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -21,7 +21,6 @@ from adbc_drivers_dev.generate import GenerateConfig, LangConfig
 def test_model_default() -> None:
     config = GenerateConfig.model_validate({})
     assert config.driver == "(unknown)"
-    assert config.environment is None
     assert config.private is False
     assert config.lang == {}
     assert config._processed_secrets == {
@@ -40,7 +39,7 @@ def test_model_default() -> None:
     assert config.to_dict() == {
         "driver": "(unknown)",
         "repository": "(unknown)",
-        "environment": None,
+        "concurrency_key": None,
         "private": False,
         "lang": {},
         "secrets": {
@@ -66,12 +65,6 @@ def test_model_custom() -> None:
     config = GenerateConfig.model_validate({"driver": "postgresql"})
     assert config.driver == "postgresql"
     assert config.to_dict()["driver"] == "postgresql"
-    assert config == config
-    assert config != GenerateConfig.model_validate({})
-
-    config = GenerateConfig.model_validate({"environment": "ci-env"})
-    assert config.environment == "ci-env"
-    assert config.to_dict()["environment"] == "ci-env"
     assert config == config
     assert config != GenerateConfig.model_validate({})
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -52,6 +52,7 @@ def test_model_default() -> None:
         "permissions": {},
         "aws": None,
         "gcloud": False,
+        "azure": False,
         "validation": {
             "extra_dependencies": {},
             "extra_pypi_dependencies": {},


### PR DESCRIPTION
More verbose but more flexible. The motivation is to be able to test certain databases where there are both local and cloud-hosted options and not require all runs to have access to the cloud credentials (only the sub-job that tests the cloud-hosted configuration).