### PR TITLE
feat!: allow enabling AWS per-validation-config

### DIFF
--- a/adbc_drivers_dev/generate.py
+++ b/adbc_drivers_dev/generate.py
@@ -105,9 +105,17 @@ class LangValidateSpec(BaseModel):
         default=None,
         description="Name of a GitHub Actions Environment to activate",
     )
+    aws: bool = Field(
+        default=False,
+        description="Log in to AWS in this config. Expects AWS_ROLE, AWS_ROLE_SESSION_NAME secrets",
+    )
     azure: bool = Field(
         default=False,
         description="Log in to Azure in this config. Expects AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_CLIENT_SECRET secrets",
+    )
+    gcloud: bool = Field(
+        default=False,
+        description="Log in to Google Cloud in this config. Expects GCLOUD_SERVICE_ACCOUNT, GCLOUD_WORKLOAD_IDENTITY_PROVIDER secrets",
     )
 
 
@@ -151,6 +159,18 @@ class LangTestConfig(BaseModel):
     environment: str | None = Field(
         default=None,
         description="Name of a GitHub Actions Environment to activate",
+    )
+    aws: bool = Field(
+        default=False,
+        description="Log in to AWS in this config. Expects AWS_ROLE, AWS_ROLE_SESSION_NAME secrets",
+    )
+    azure: bool = Field(
+        default=False,
+        description="Log in to Azure in this config. Expects AZURE_CLIENT_ID, AZURE_TENANT_ID, and AZURE_CLIENT_SECRET secrets",
+    )
+    gcloud: bool = Field(
+        default=False,
+        description="Log in to Google Cloud in this config. Expects GCLOUD_SERVICE_ACCOUNT, GCLOUD_WORKLOAD_IDENTITY_PROVIDER secrets",
     )
 
 
@@ -348,7 +368,7 @@ gcloud = true"""
             for lang in self.lang.values()
             if lang
             for config in lang.validation.configs
-        )
+        ) or any(lang.test.azure for lang in self.lang.values() if lang)
 
     @model_validator(mode="after")
     def default_repository(self) -> "GenerateConfig":

--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -164,7 +164,7 @@ jobs:
           pixi-version: v0.72.0
           run-install: false
 
-<% if aws %>
+<% if aws and lang_config.test.aws %>
       - name: AWS Login
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
@@ -172,7 +172,7 @@ jobs:
           role-to-assume: ${{ secrets.aws_role }}
           role-session-name: ${{ secrets.aws_role_session_name }}
 <% endif %>
-<% if gcloud %>
+<% if gcloud and lang_config.test.gcloud %>
       - name: Google Cloud Login
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
@@ -290,7 +290,7 @@ jobs:
         include:
           # I think we only need to test one platform, but we can change that later
 <% for config in lang_config.validation.configs %>
-          - { platform: linux, arch: amd64, runner: ubuntu-latest, service_name: "<{config.service_name}>", vendor_version: "<{config.vendor_version}>", environment: <% if config.environment %>"<{config.environment}>"<% else %>null<% endif %>, azure: <{ "true" if config.azure else "false" }> }
+          - { platform: linux, arch: amd64, runner: ubuntu-latest, service_name: "<{config.service_name}>", vendor_version: "<{config.vendor_version}>", environment: <% if config.environment %>"<{config.environment}>"<% else %>null<% endif %>, aws: <{ "true" if config.aws else "false" }>, azure: <{ "true" if config.azure else "false" }>, gcloud: <{ "true" if config.gcloud else "false" }> }
 <% endfor %>
     environment: ${{ matrix.environment }}
     permissions:
@@ -356,6 +356,7 @@ jobs:
 <% if aws %>
       - name: AWS Login
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
+        if: matrix.aws
         with:
           aws-region: <{aws.region}>
           role-to-assume: ${{ secrets.aws_role }}
@@ -364,6 +365,7 @@ jobs:
 <% if gcloud %>
       - name: Google Cloud Login
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        if: matrix.gcloud
         with:
           service_account: ${{ secrets.gcloud_service_account }}
           workload_identity_provider: ${{ secrets.gcloud_workload_identity_provider }}


### PR DESCRIPTION
BREAKING CHANGE: existing configs using AWS/Google Cloud will now need to explicitly opt in to them in generate.toml