### PR TITLE
feat: add optional ci/scripts/post-build.sh hook to the release Build job

### DIFF
--- a/adbc_drivers_dev/templates/test.yaml
+++ b/adbc_drivers_dev/templates/test.yaml
@@ -599,6 +599,10 @@ jobs:
           set +a
           pixi run adbc-make check CI=true VERBOSE=true DRIVER=<{driver}> IMPL_LANG=<{lang}> <{' '.join(lang_config.build.additional_make_args) }><% if release %> RELEASE=true<% endif %>
 
+          if [[ -f ci/scripts/post-build.sh ]]; then
+            ./ci/scripts/post-build.sh release ${{ matrix.platform }} ${{ matrix.arch }}
+          fi
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: drivers-${{ matrix.platform }}-${{ matrix.arch }}


### PR DESCRIPTION
## Summary
- The release `build` job runs `pixi run adbc-make check` and immediately uploads the resulting artifact via `actions/upload-artifact`, with no hook point in between.
- This means a driver repo has no way to verify the freshly-built binary (e.g. check for unwanted dynamic library dependencies) before it ships.
- Adds an optional `ci/scripts/post-build.sh` hook after the `check` step, following the exact same run-if-present convention as the existing `pre-build.sh`/`pre-test.sh`/`post-test.sh` hooks.

## Motivating use case
A driver with a cgo dependency on a native library may need to switch its release binaries to static linking on some platforms, and verify post-build that the shipped binary has no leftover dynamic dependency (e.g. via `otool -L`/`objdump -p`/`readelf -d`). That requires a hook after the binary exists but before it's uploaded/packaged.