### PR TITLE
feat: check for correctly named Init symbol post-build

### DIFF
--- a/adbc_drivers_dev/make_checks.py
+++ b/adbc_drivers_dev/make_checks.py
@@ -85,8 +85,12 @@ def check_linux_symbols(
         )
 
     driver_init = f"AdbcDriver{driver.lower().capitalize()}Init"
-    if driver_init not in exported_symbols:
-        raise RuntimeError(f"{driver_init} should be exported from {binary}")
+    missing_symbols = set()
+    for required_symbol in (driver_init, "AdbcDriverInit"):
+        if required_symbol not in exported_symbols:
+            missing_symbols.add(required_symbol)
+    if missing_symbols:
+        raise RuntimeError(f"{', '.join(missing_symbols)} should be exported from {binary}")
 
     limits = {
         "manylinux2014": ("2.17", "3.4.19"),

--- a/adbc_drivers_dev/make_checks.py
+++ b/adbc_drivers_dev/make_checks.py
@@ -90,7 +90,9 @@ def check_linux_symbols(
         if required_symbol not in exported_symbols:
             missing_symbols.add(required_symbol)
     if missing_symbols:
-        raise RuntimeError(f"{', '.join(missing_symbols)} should be exported from {binary}")
+        raise RuntimeError(
+            f"{', '.join(missing_symbols)} should be exported from {binary}"
+        )
 
     limits = {
         "manylinux2014": ("2.17", "3.4.19"),

--- a/adbc_drivers_dev/make_checks.py
+++ b/adbc_drivers_dev/make_checks.py
@@ -67,18 +67,26 @@ def _read_linux_symbols_in_docker(
     )
 
 
-def check_linux_symbols(symbols: list[str], binary: Path, manylinux: str) -> None:
+def check_linux_symbols(
+    symbols: list[str], binary: Path, manylinux: str, driver: str
+) -> None:
     bad_symbols = []
+    exported_symbols = set()
     for symbol in symbols:
         if " T " not in symbol:
             continue
         _, _, name = symbol.partition(" T ")
+        exported_symbols.add(name)
         if not name.startswith("Adbc"):
             bad_symbols.append(name)
     if bad_symbols:
         raise RuntimeError(
             f"{', '.join(bad_symbols[:3])}... ({len(bad_symbols)} symbols total) should not be exported from {binary}"
         )
+
+    driver_init = f"AdbcDriver{driver.lower().capitalize()}Init"
+    if driver_init not in exported_symbols:
+        raise RuntimeError(f"{driver_init} should be exported from {binary}")
 
     limits = {
         "manylinux2014": ("2.17", "3.4.19"),
@@ -113,7 +121,7 @@ def _check_linux(make_env: MakeEnv, make_config: MakeConfig, binary: Path) -> No
         raise RuntimeError(
             "Cannot run Linux compatibility checks on non-Linux host without Docker"
         )
-    check_linux_symbols(symbols, binary, make_config.manylinux)
+    check_linux_symbols(symbols, binary, make_config.manylinux, make_config.driver)
 
 
 def _check_macos(binary: Path) -> None:

--- a/tests/test_make_checks.py
+++ b/tests/test_make_checks.py
@@ -24,6 +24,7 @@ def test_check_linux_symbols_accepts_adbc_exports() -> None:
         [
             "000000 T AdbcDatabaseNew",
             "000000 T AdbcConnectionInit",
+            "000000 T AdbcDriverInit",
             "000000 T AdbcDriverMultiwordnameInit",
             "         U external_symbol",
             "000000 B _cgo_runtime",
@@ -39,6 +40,7 @@ def test_check_linux_symbols_rejects_non_adbc_exports() -> None:
         make_checks.check_linux_symbols(
             [
                 "000000 T AdbcDatabaseNew",
+                "000000 T AdbcDriverInit",
                 "000000 T AdbcDriverDriverInit",
                 "000000 T bad_symbol",
             ],
@@ -51,7 +53,17 @@ def test_check_linux_symbols_rejects_non_adbc_exports() -> None:
 def test_check_linux_symbols_requires_driver_init() -> None:
     with pytest.raises(RuntimeError, match="AdbcDriverMultiwordnameInit"):
         make_checks.check_linux_symbols(
-            ["000000 T AdbcDriverMultiWordNameInit"],
+            ["000000 T AdbcDriverInit", "000000 T AdbcDriverMultiWordNameInit"],
+            Path("libadbc_driver_multiwordname.so"),
+            "manylinux2014",
+            "multiwordname",
+        )
+
+
+def test_check_linux_symbols_requires_generic_driver_init() -> None:
+    with pytest.raises(RuntimeError, match="AdbcDriverInit"):
+        make_checks.check_linux_symbols(
+            ["000000 T AdbcDriverMultiwordnameInit"],
             Path("libadbc_driver_multiwordname.so"),
             "manylinux2014",
             "multiwordname",
@@ -61,7 +73,11 @@ def test_check_linux_symbols_requires_driver_init() -> None:
 def test_check_linux_symbols_enforces_manylinux_limits() -> None:
     with pytest.raises(RuntimeError, match="GLIBC_2.18"):
         make_checks.check_linux_symbols(
-            ["000000 T AdbcDriverDriverInit", " U function@GLIBC_2.18"],
+            [
+                "000000 T AdbcDriverInit",
+                "000000 T AdbcDriverDriverInit",
+                " U function@GLIBC_2.18",
+            ],
             Path("driver.so"),
             "manylinux2014",
             "driver",
@@ -69,6 +85,7 @@ def test_check_linux_symbols_enforces_manylinux_limits() -> None:
 
     make_checks.check_linux_symbols(
         [
+            "000000 T AdbcDriverInit",
             "000000 T AdbcDriverDriverInit",
             " U function@GLIBC_2.28",
             " U function@GLIBCXX_3.4.32",
@@ -82,7 +99,7 @@ def test_check_linux_symbols_enforces_manylinux_limits() -> None:
 def test_check_linux_symbols_rejects_unknown_policy() -> None:
     with pytest.raises(ValueError, match="Unsupported manylinux policy"):
         make_checks.check_linux_symbols(
-            ["000000 T AdbcDriverDriverInit"],
+            ["000000 T AdbcDriverInit", "000000 T AdbcDriverDriverInit"],
             Path("driver.so"),
             "unknown",
             "driver",

--- a/tests/test_make_checks.py
+++ b/tests/test_make_checks.py
@@ -24,39 +24,69 @@ def test_check_linux_symbols_accepts_adbc_exports() -> None:
         [
             "000000 T AdbcDatabaseNew",
             "000000 T AdbcConnectionInit",
+            "000000 T AdbcDriverMultiwordnameInit",
             "         U external_symbol",
             "000000 B _cgo_runtime",
         ],
         Path("driver.so"),
         "manylinux2014",
+        "multiwordname",
     )
 
 
 def test_check_linux_symbols_rejects_non_adbc_exports() -> None:
     with pytest.raises(RuntimeError, match="bad_symbol"):
         make_checks.check_linux_symbols(
-            ["000000 T AdbcDatabaseNew", "000000 T bad_symbol"],
+            [
+                "000000 T AdbcDatabaseNew",
+                "000000 T AdbcDriverDriverInit",
+                "000000 T bad_symbol",
+            ],
             Path("driver.so"),
             "manylinux2014",
+            "driver",
+        )
+
+
+def test_check_linux_symbols_requires_driver_init() -> None:
+    with pytest.raises(RuntimeError, match="AdbcDriverMultiwordnameInit"):
+        make_checks.check_linux_symbols(
+            ["000000 T AdbcDriverMultiWordNameInit"],
+            Path("libadbc_driver_multiwordname.so"),
+            "manylinux2014",
+            "multiwordname",
         )
 
 
 def test_check_linux_symbols_enforces_manylinux_limits() -> None:
     with pytest.raises(RuntimeError, match="GLIBC_2.18"):
         make_checks.check_linux_symbols(
-            [" U function@GLIBC_2.18"], Path("driver.so"), "manylinux2014"
+            ["000000 T AdbcDriverDriverInit", " U function@GLIBC_2.18"],
+            Path("driver.so"),
+            "manylinux2014",
+            "driver",
         )
 
     make_checks.check_linux_symbols(
-        [" U function@GLIBC_2.28", " U function@GLIBCXX_3.4.32"],
+        [
+            "000000 T AdbcDriverDriverInit",
+            " U function@GLIBC_2.28",
+            " U function@GLIBCXX_3.4.32",
+        ],
         Path("driver.so"),
         "manylinux_2_28",
+        "driver",
     )
 
 
 def test_check_linux_symbols_rejects_unknown_policy() -> None:
     with pytest.raises(ValueError, match="Unsupported manylinux policy"):
-        make_checks.check_linux_symbols([], Path("driver.so"), "unknown")
+        make_checks.check_linux_symbols(
+            ["000000 T AdbcDriverDriverInit"],
+            Path("driver.so"),
+            "unknown",
+            "driver",
+        )
 
 
 def test_check_macos_rejects_new_deployment_target(


### PR DESCRIPTION
## What's Changed

Validate that the expected AdbcDriverInit symbol is present.

Assisted-by: GPT-5.6 Sol <codex@openai.com>