### PR TITLE
test: run `check` in integration test

### DIFF
--- a/.github/workflows/test_local.yaml
+++ b/.github/workflows/test_local.yaml
@@ -57,6 +57,17 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
         if: runner.os == 'Linux'
 
+      - name: Add dumpbin to PATH
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $dumpbin = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe' | Select-Object -First 1
+          if (-not $dumpbin) {
+            throw "Could not find dumpbin.exe using vswhere"
+          }
+          Split-Path $dumpbin -Parent | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Test
         run: |
           pixi run --locked test

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -513,7 +513,7 @@ def test_go_actual_release_ci(go_driver_root: tuple[Path, Path]) -> None:
     _, driver_root = go_driver_root
     prefix, suffix = shared_library_affix()
     result = subprocess.check_output(
-        ["adbc-make", "-a", "CI=true"],
+        ["adbc-make", "-a", "check", "CI=true"],
         cwd=driver_root,
         text=True,
         stderr=subprocess.STDOUT,
@@ -572,7 +572,7 @@ def test_rust_actual_release(rust_driver_root: tuple[Path, Path]) -> None:
 def test_rust_actual_release_ci(rust_driver_root: tuple[Path, Path]) -> None:
     prefix, suffix = shared_library_affix()
     result = subprocess.check_output(
-        ["adbc-make", "-a", "CI=true"],
+        ["adbc-make", "-a", "check", "CI=true"],
         cwd=rust_driver_root[1],
         text=True,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
## What's Changed

In tests that exercise the make infrastructure on the dummy drivers, actually run the post-build checks too.